### PR TITLE
Add env var for CF_STACK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,3 +21,5 @@ RUN /bin/herokuish buildpack install \
 
 # backwards compatibility
 ADD ./rootfs /
+
+ENV CF_STACK=cflinuxfs2


### PR DESCRIPTION
Setting CF_STACK=cflinuxfs2 is required in some build packs to signal
that we’re on the updated cflinuxfs2 stack image.
