### PR TITLE
Use cf buildpacks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,3 +21,5 @@ RUN /bin/herokuish buildpack install \
 
 # backwards compatibility
 ADD ./rootfs /
+
+ENV CF_STACK=cflinuxfs2

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,18 @@ RUN curl https://github.com/gliderlabs/herokuish/releases/download/v0.3.1/heroku
 		--silent -L | tar -xzC /bin
 
 # Install herokuish supported buildpacks and entrypoints
-RUN /bin/herokuish buildpack install \
-	&& ln -s /bin/herokuish /build \
+RUN ln -s /bin/herokuish /build \
 	&& ln -s /bin/herokuish /start \
 	&& ln -s /bin/herokuish /exec
+
+RUN git clone --recursive https://github.com/cloudfoundry/java-buildpack /tmp/buildpacks/java-buildpack && \
+		git clone --recursive https://github.com/cloudfoundry/ruby-buildpack /tmp/buildpacks/ruby-buildpack && \
+		git clone --recursive https://github.com/cloudfoundry/nodejs-buildpack /tmp/buildpacks/nodejs-buildpack && \
+		git clone --recursive https://github.com/cloudfoundry/php-buildpack /tmp/buildpacks/php-buildpack && \
+		git clone --recursive https://github.com/cloudfoundry/go-buildpack /tmp/buildpacks/go-buildpack && \
+		git clone --recursive https://github.com/cloudfoundry/python-buildpack /tmp/buildpacks/python-buildpack && \
+		git clone --recursive https://github.com/cloudfoundry/staticfile-buildpack /tmp/buildpacks/staticfile-buildpack && \
+		git clone --recursive https://github.com/cloudfoundry/binary-buildpack /tmp/buildpacks/binary-buildpack
 
 # backwards compatibility
 ADD ./rootfs /


### PR DESCRIPTION
By removing the `herokuish buildpack install` command we prevent the
Heroku build packs from being fetched in the image. Instead, we `git
clone` the common CF Buildpacks from
https://github.com/cloudfoundry-community/cf-docs-contrib/wiki/Buildpack
s and put them in the place the Herokuish build process will look for
them.
